### PR TITLE
Added 100ms sleep default for data generator

### DIFF
--- a/flink-stateful-tutorial/config/job.properties
+++ b/flink-stateful-tutorial/config/job.properties
@@ -24,3 +24,4 @@ transaction.input.topic=transaction.log.1
 query.input.topic=query.input.log.1
 query.output.topic=query.output.log.1
 num.items=1000000
+sleep=100


### PR DESCRIPTION
This is a conservative default intended to stop people leaving this out and accidentally filling their clusters with generated test data.