### PR TITLE
Update README.md and don't use deprecated invoke method

### DIFF
--- a/flink-simple-tutorial/src/test/java/com/cloudera/streaming/examples/flink/HeapMonitorPipelineTest.java
+++ b/flink-simple-tutorial/src/test/java/com/cloudera/streaming/examples/flink/HeapMonitorPipelineTest.java
@@ -52,7 +52,7 @@ public class HeapMonitorPipelineTest {
         HeapMonitorPipeline.computeHeapAlerts(testInput, ParameterTool.fromArgs(new String[]{"--alertMask", alertMask}))
                 .addSink(new SinkFunction<HeapAlert>() {
                     @Override
-                    public void invoke(HeapAlert value) {
+                    public void invoke(HeapAlert value, Context context) {
                         testOutput.add(value);
                     }
                 })


### PR DESCRIPTION
Besides the small fixes, the recent update to the data generator's sleep value in the default config made the stateful tutorial's documentation inconsistent with the actual behavior, this PR fixes it.